### PR TITLE
Config now grabs DB creds and location from Heroku Env.

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -14,18 +14,20 @@
  * @package WordPress
  */
 
-// ** MySQL settings - You can get this info from your web host ** //
+// ** Heroku Postgres settings - from Heroku Environment ** //
+$db = parse_url($_ENV["DATABASE_URL"]);
+
 /** The name of the database for WordPress */
-define('DB_NAME', 'database_name_here');
+define('DB_NAME', trim($db["path"],"/"));
 
 /** MySQL database username */
-define('DB_USER', 'username_here');
+define('DB_USER', $db["user"]);
 
 /** MySQL database password */
-define('DB_PASSWORD', 'password_here');
+define('DB_PASSWORD', $db["pass"]);
 
 /** MySQL hostname */
-define('DB_HOST', 'localhost');
+define('DB_HOST', $db["host"]);
 
 /** Database Charset to use in creating database tables. */
 define('DB_CHARSET', 'utf8');


### PR DESCRIPTION
A small change that will allow deployment of wordpress to Heroku much smoother. Instead of having the developer get the creds and db location from Heroku, this change has the Wordpress Install find out automatically.

If you do accept this change, you might consider making the wp-config-sample.php file into the default wp-config.php file as it should work right out of the box. Also, the readme will need updating.

Let me know if you'd like any assistance.

Cheers,

James.
