### PR TITLE
Added .htaccess file to make permalinks work

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress


### PR DESCRIPTION
This commit fiexes issue #7 

https://github.com/mhoofman/wordpress-heroku/issues/7

An .htaccess file is required in order to make permalinks work properly. At the moment when a user changes settings and uses permalinks wordpress would create a .htaccess file if it doesn't exist, but this file will disappear when the app is reloaded(ex. with 'heroku restart')
