### PR TITLE
Warmfix/readme salt update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Copy the `wp-config.php`
 
     $ cp wp-config-sample.php wp-config.php
 
+Update unique keys and salts in `wp-config.php` on lines 48-55. Wordpress can provide random values [here](https://api.wordpress.org/secret-key/1.1/salt/).
+
+    define('AUTH_KEY',         'put your unique phrase here');
+    define('SECURE_AUTH_KEY',  'put your unique phrase here');
+    define('LOGGED_IN_KEY',    'put your unique phrase here');
+    define('NONCE_KEY',        'put your unique phrase here');
+    define('AUTH_SALT',        'put your unique phrase here');
+    define('SECURE_AUTH_SALT', 'put your unique phrase here');
+    define('LOGGED_IN_SALT',   'put your unique phrase here');
+    define('NONCE_SALT',       'put your unique phrase here');
+
 Clear `.gitignore` and commit `wp-config.php`
 
     $ >.gitignore


### PR DESCRIPTION
Small clean up of stray whitespace and random tabs in readme.

Outlining the necessary step of defining unique unique keys and salts in `wp-config.php`
