### PR TITLE
Add local setup instructions for linux, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ CREATE USER wordpress WITH PASSWORD 'wordpress';
 GRANT ALL PRIVILEGES ON DATABASE wordpress to wordpress;
 ```
 
-* In your Apache config, add a `SetEnv` directive like `SetEnv DATABASE_URL postgres://wordpress:wordpress@localhost:5432/wordpress"`
-* Change the first line of your `wp-config.php` to set `$db` to use `$_SERVER` if `DATABASE_URL` not found in `$_ENV`:
+* In your Apache config, add a `SetEnv` directive like `SetEnv DATABASE_URL postgres://wordpress:wordpress@localhost:5432/wordpress`
+* Change the first line of your `wp-config.php` to use `$_SERVER["DATABASE_URL"]` if `DATABASE_URL` not found in `$_ENV`:
 
 ```
 if (isset($_ENV["DATABASE_URL"]))


### PR DESCRIPTION
Adds some instructions for local dev environment setup to the README, if you're not using MAMP. 

Not sure Apache `SetEnv` variables is the best way of doing it, but it worked for me and seemed less OS-specific than other ways of pushing env vars into Apache. 

Hopefully will save others some hours of frustration.
