### PR TITLE
Update wp-admin.css

### DIFF
--- a/wp-admin/css/wp-admin.css
+++ b/wp-admin/css/wp-admin.css
@@ -1383,7 +1383,7 @@ form.upgrade .hint {
 }
 
 #adminmenuwrap {
-	position: relative;
+	position: fixed;
 	float: left;
 }
 


### PR DESCRIPTION
If admin panel height is longer than this fixed position help to navigate menu without scroll.
