### PR TITLE
Allow a domain to load static files from itself

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -83,7 +83,7 @@ define('WPLANG', '');
  */
 define('WP_DEBUG', false);
 
-/** Load static files from itself */
+/** Load static files from the current domain. */
 define("WP_SITEURL", "http://" . $_SERVER["HTTP_HOST"]);
 
 /* That's all, stop editing! Happy blogging. */


### PR DESCRIPTION
Right now, example.herokuapp.com tries to load static files from example.com which either does not exist or pointing to sub.example.com which pointing to example.herokuapp.com (causing a redirect loop).
