### PR TITLE
Database URL problem on MacOS with MAMP

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -15,7 +15,7 @@
  */
 
 // ** Heroku Postgres settings - from Heroku Environment ** //
-$db = parse_url($_ENV["DATABASE_URL"]);
+$db = parse_url($_ENV["DATABASE_URL"] ? $_ENV["DATABASE_URL"] : "postgres://wordpress:wordpress@localhost:5432/wordpress");
 
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */


### PR DESCRIPTION
Currently it just call env DATABASE_URL. But this could be a problem on MacOSX with MAMP, since the envvars doesn't work (eg. even if the database name is wrong, wordpress can still run). What I did is call the URL "postgres://wordpress:wordpress@localhost:5432/wordpress" when DATABASE_URL is not set (i.e. running locally) for local development. Maybe there is a way to actually  set envs on MAMP? Anyway I haven't found that yet, so this is a workaround.

p.s. I also modified the tutorial in https://github.com/mhoofman/wordpress-heroku/wiki/Setting-Up-a-Local-Environment-on-Mac-OS-X . If this pr is not accepted, maybe you should change it back.